### PR TITLE
Adding WiFi specific event group

### DIFF
--- a/esp32/src/esp32_wifi.c
+++ b/esp32/src/esp32_wifi.c
@@ -39,7 +39,9 @@ static wifi_mode_t s_cur_mode = WIFI_MODE_NULL;
 
 esp_err_t esp32_wifi_ev(system_event_t *ev) {
   bool send_ev = false;
+  bool send_wifi_ev = false;
   enum mgos_net_event mg_ev;
+  enum mgos_wifi_event wifi_ev;
   system_event_info_t *info = &ev->event_info;
   switch (ev->event_id) {
     case SYSTEM_EVENT_STA_START: {
@@ -64,6 +66,8 @@ esp_err_t esp32_wifi_ev(system_event_t *ev) {
       send_ev = true;
       break;
     case SYSTEM_EVENT_AP_STACONNECTED: {
+      wifi_ev = MGOS_WIFI_AP_STA_CONNECTED;
+      send_wifi_ev = true;
       const uint8_t *mac = ev->event_info.sta_connected.mac;
       LOG(LL_INFO, ("WiFi AP: station %02X%02X%02X%02X%02X%02X (aid %d) %s",
                     mac[0], mac[1], mac[2], mac[3], mac[4], mac[5],
@@ -71,6 +75,8 @@ esp_err_t esp32_wifi_ev(system_event_t *ev) {
       break;
     }
     case SYSTEM_EVENT_AP_STADISCONNECTED: {
+      wifi_ev = MGOS_WIFI_AP_STA_DISCONNECTED;
+      send_wifi_ev = true;
       const uint8_t *mac = ev->event_info.sta_disconnected.mac;
       LOG(LL_INFO, ("WiFi AP: station %02X%02X%02X%02X%02X%02X (aid %d) %s",
                     mac[0], mac[1], mac[2], mac[3], mac[4], mac[5],
@@ -111,6 +117,10 @@ esp_err_t esp32_wifi_ev(system_event_t *ev) {
 
   if (send_ev) {
     mgos_wifi_dev_on_change_cb(mg_ev);
+  }
+
+  if (send_wifi_ev) {
+    mgos_wifi_dev_ap_on_change_cb(wifi_ev);
   }
 
   return ESP_OK;

--- a/include/mgos_wifi.h
+++ b/include/mgos_wifi.h
@@ -20,10 +20,27 @@
 
 #include <stdbool.h>
 #include "mgos_sys_config.h"
+#include "mgos_event.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
+
+#define MGOS_WIFI_EV_BASE MGOS_EVENT_BASE('W', 'F', 'I')
+
+/*
+ * Event types which are delivered to the callback registered with
+ * `mgos_event_add_handler()` or `mgos_event_add_group_handler()`, see
+ * example in the documentation for `MGOS_EVENT_GRP_NET`.
+ */
+enum mgos_wifi_event {
+  MGOS_WIFI_AP_STA_CONNECTED = MGOS_WIFI_EV_BASE,
+  MGOS_WIFI_AP_STA_DISCONNECTED,
+};
+
+struct mgos_wifi_ap_sta_connected_arg {
+  uint8_t mac[6];
+};
 
 /*
  * Setup wifi station; `struct mgos_config_wifi_sta` looks as follows:

--- a/include/mgos_wifi_hal.h
+++ b/include/mgos_wifi_hal.h
@@ -42,6 +42,8 @@ bool mgos_wifi_dev_get_ip_info(int if_instance,
 /* Invoke this when Wifi connection state changes. */
 void mgos_wifi_dev_on_change_cb(enum mgos_net_event ev);
 
+void mgos_wifi_dev_ap_on_change_cb(enum mgos_wifi_event ev);
+
 bool mgos_wifi_dev_start_scan(void);
 /*
  * Invoke this when the scan is done. In case of error, pass num_res < 0.

--- a/src/mgos_wifi.c
+++ b/src/mgos_wifi.c
@@ -30,6 +30,7 @@
 #include "mgos_sys_config.h"
 #include "mgos_system.h"
 #include "mgos_timers.h"
+#include "mgos_event.h"
 
 #include "mongoose.h"
 
@@ -150,6 +151,14 @@ static void mgos_wifi_on_change_cb(void *arg) {
   if (reconnect && s_sta_should_reconnect) {
     mgos_wifi_connect();
   }
+}
+
+void mgos_wifi_dev_ap_on_change_cb(enum mgos_wifi_event ev){
+  // struct mgos_wifi_ap_sta_connected_arg evd = {
+  //     //
+  // };
+  // mgos_event_trigger(ev, &evd);
+  mgos_event_trigger(ev, NULL); // not sure correct way to pass ev info from platform specific files
 }
 
 void mgos_wifi_dev_on_change_cb(enum mgos_net_event ev) {
@@ -480,6 +489,11 @@ static void dns_ev_handler(struct mg_connection *c, int ev, void *ev_data,
 }
 
 bool mgos_wifi_init(void) {
+
+  if (!mgos_event_register_base(MGOS_WIFI_EV_BASE, "wfi")) {
+    // return MGOS_INIT_NET_INIT_FAILED; // Should we trigger NET init event failed?? Or add a new one in mgos_init.h for wifi?
+  }
+
   s_wifi_lock = mgos_rlock_create();
   mgos_register_config_validator(validate_wifi_cfg);
   mgos_wifi_dev_init();


### PR DESCRIPTION
In an effort to kickstart having event callbacks for resolving #5 and https://github.com/cesanta/mongoose-os/issues/420 ... I went ahead and started the process of building out wifi specific events (since wifi lib now only uses NET events).

Few things remaining:
- [ ] Add esp8266 handling
- [ ] Check if possible to add handling for other platforms
- [ ] Do we fail init if unable to register event base for WIFI?
- [ ] Maybe add other specific wifi events
- [ ] Not sure how you guys would want (or how I should) pass/set event data, hoping someone can help with that