### PR TITLE
add mgos_wifi_sta_get_signal_strength from rssi value

### DIFF
--- a/include/mgos_wifi.h
+++ b/include/mgos_wifi.h
@@ -178,6 +178,12 @@ char *mgos_wifi_get_sta_default_dns(void);
 int mgos_wifi_sta_get_rssi(void);
 
 /*
+ * Returns signal strength of station if connected to an AP, otherwise 0.
+ * Note: strength is returned as a percentage (without % symbol), out of 100
+ */
+int mgos_wifi_sta_get_signal_strength(void);
+
+/*
  * Auth mode for networks obtained with `mgos_wifi_scan()`.
  */
 enum mgos_wifi_auth_mode {

--- a/src/mgos_wifi.c
+++ b/src/mgos_wifi.c
@@ -479,6 +479,21 @@ static void dns_ev_handler(struct mg_connection *c, int ev, void *ev_data,
   (void) user_data;
 }
 
+int mgos_wifi_sta_get_signal_strength(void) {
+  int quality;
+  int rssi = mgos_wifi_sta_get_rssi();
+
+  if (rssi == 0 || rssi <= -100) {
+    quality = 0;
+  } else if (rssi >= -50) {
+    quality = 100;
+  } else {
+    quality = 2 * (rssi + 100);
+  }
+
+  return quality;
+}
+
 bool mgos_wifi_init(void) {
   s_wifi_lock = mgos_rlock_create();
   mgos_register_config_validator(validate_wifi_cfg);


### PR DESCRIPTION
Most end users will have no idea how to convert RSSI (or even just understand the values), so I added a method, `mgos_wifi_sta_get_signal_strength` which will convert from RSSI value, to a percentage value, out of 100