### PR TITLE
[esp32] Fix mgos_wifi_scan never completing if wifi in connecting state

### DIFF
--- a/esp32/src/esp32_wifi.c
+++ b/esp32/src/esp32_wifi.c
@@ -64,6 +64,7 @@ esp_err_t esp32_wifi_ev(system_event_t *ev) {
       mg_ev = MGOS_WIFI_EV_STA_DISCONNECTED;
       mg_ev_arg = &sta_disconnected;
       send_mg_ev = true;
+      s_connecting = false;
       break;
     case SYSTEM_EVENT_STA_CONNECTED:
       mg_ev = MGOS_WIFI_EV_STA_CONNECTED;
@@ -515,13 +516,13 @@ bool mgos_wifi_dev_sta_disconnect(void) {
   wifi_mode_t cur_mode = esp32_wifi_get_mode();
   if (cur_mode == WIFI_MODE_NULL || cur_mode == WIFI_MODE_AP) return false;
   esp_wifi_disconnect();
+  s_connecting = false;
   /* If we are in station-only mode, stop WiFi task as well. */
   if (cur_mode == WIFI_MODE_STA) {
     esp_err_t r = esp_wifi_stop();
     if (r == ESP_ERR_WIFI_NOT_INIT) r = ESP_OK; /* Nothing to stop. */
     if (r == ESP_OK) {
       s_started = false;
-      s_connecting = false;
     }
   }
   return true;


### PR DESCRIPTION
**This PR**
This PR adds a connecting variable to determine if wifi is in connecting state, and if so, it calls `esp_wifi_disconnect` before calling scan for wifi networks.

I tested this using my captive portal demo app:
https://github.com/tripflex/captive-portal-wifi-stack-demo

And it fixed the problem perfectly.  Because the connect timer is still running from mgos, it will still continue connection attempt after scan is completed, moving on to next sta, etc.

---
Related to: https://github.com/mongoose-os-libs/wifi/issues/18
and: https://github.com/tripflex/captive-portal-wifi-stack/issues/1

If wifi sta is enabled and is attempting to connect to a non-existent SSID, calling `mgos_wifi_scan` will never complete and `mos console` shows this error:

```
W (24763) wifi: Now is connecting, user scan invalid now!
```

Which if the SSID is not in range or does not exist, it will never end up connecting to anything, and scan is never actually called.

Instead of having some kind of hack in our libraries or apps, I feel as though this should be handled through the wifi lib to stop the connection attempt and actually run the scan, instead of just printing an error to console.

Related to:
https://github.com/espressif/esp-idf/issues/2497

Which is related to the 3.0.x IDF versions

Looks like this is how they fixed it in wifimanager port for esp:
https://github.com/alanswx/ESPAsyncWiFiManager/pull/45/files

IDF Docs specifically reference this issue as well:
https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/wifi.html#scan-when-wi-fi-is-connecting

mos-libs issue: https://github.com/cesanta/mos-libs/issues/26

#23 