### PR TITLE
added options to includes all channel scan and 20mhz bw ap

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -84,7 +84,9 @@ conds:
     apply:
       config_schema:
         - ["wifi.ap.keep_enabled", "b", true, {title: "Keep AP enabled when station is on"}]
+        - ["wifi.ap.bandwidth_20mhz", "b", false, {title: "enable 20MHz bandwidth AP operation"}]
         - ["wifi.sta_ps_mode", "i", 0, {title: "Power save mode for station: 0 - none, 1 - min, 2 - max."}]
+        - ["wifi.sta_all_chan_scan", "b", false, {title: "true to scan all channels or false to perform fast scan"}]
       cdefs:
         MGOS_WIFI_ENABLE_AP_STA: 1
 

--- a/src/esp32/esp32_wifi.c
+++ b/src/esp32/esp32_wifi.c
@@ -301,6 +301,8 @@ bool mgos_wifi_dev_sta_setup(const struct mgos_config_wifi_sta *cfg) {
   /* In case already connected, disconnect. */
   esp_wifi_disconnect();
 
+  stacfg->scan_method = (wifi_scan_method_t)mgos_sys_config_get_wifi_sta_all_chan_scan();
+
   strncpy((char *) stacfg->ssid, cfg->ssid, sizeof(stacfg->ssid));
   if (mgos_conf_str_empty(cfg->user) /* Not using EAP */ &&
       !mgos_conf_str_empty(cfg->pass)) {
@@ -469,6 +471,15 @@ bool mgos_wifi_dev_ap_setup(const struct mgos_config_wifi_ap *cfg) {
   r = esp_wifi_set_config(WIFI_IF_AP, &wcfg);
   if (r != ESP_OK) {
     LOG(LL_ERROR, ("WiFi AP: Failed to set config: %d", r));
+    goto out;
+  }
+  wifi_bandwidth_t bw = WIFI_BW_HT40;
+  if (cfg->bandwidth_20mhz) {
+    bw = WIFI_BW_HT20;
+  }
+  r = esp_wifi_set_bandwidth(WIFI_IF_AP, bw);
+  if (r != ESP_OK) {
+    LOG(LL_ERROR, ("WiFi AP: Failed to set the bandwidth: %d", r));
     goto out;
   }
   r = tcpip_adapter_dhcps_start(TCPIP_ADAPTER_IF_AP);


### PR DESCRIPTION
all channel scan fixes the problem where there a multiple routers with the same SSID that it is trying to connect to and instead of trying to connect to the router it first finds based on channel (could be lowest rssi) it will scan all the channels first and connect to the one with the highest rssi

also added the option to use a 20MHz bandwidth AP