### PR TITLE
Fix ESP8266 build

### DIFF
--- a/src/esp8266/esp_wifi.c
+++ b/src/esp8266/esp_wifi.c
@@ -29,13 +29,14 @@
 #include "common/cs_dbg.h"
 #include "common/cs_file.h"
 
-#include "lwip/dns.h"
 #include "mgos_gpio.h"
 #include "mgos_hal.h"
 #include "mgos_net_hal.h"
 #include "mgos_sys_config.h"
 #include "mgos_wifi.h"
 #include "mgos_wifi_hal.h"
+
+#include "lwip/dns.h"
 
 static uint8_t s_cur_mode = NULL_MODE;
 


### PR DESCRIPTION
clang-format moved `#include "lwip/dns.h"` before `#include "mgos_*.h"` and ESP8266 build fails:
```
In file included from /home/.../deps/wifi/src/esp8266/esp_wifi.c:32:0:
/opt/Espressif/cs_lwip/src/include/lwip/dns.h:120:1: error: unknown type name 'err_t'
 err_t dns_gethostbyname(const char *hostname, ip_addr_t *addr,
```