### PR TITLE
Added esp_wifi_set_protocol

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -28,7 +28,7 @@ config_schema:
   - ["wifi.ap.dhcp_end", "s", "192.168.4.100", {title: "DHCP End Address"}]
   - ["wifi.ap.trigger_on_gpio", "i", -1, {title: "Trigger AP on low GPIO"}]
   - ["wifi.ap.disable_after", "i", 0, {title: "If > 0, will disable itself after the specified number of seconds"}]
-  - ["wifi.ap.hostname", "s", "", {title: "If not empty, DNS server will resolve given host name to the IP address of AP"}]
+  - ["wifi.ap.hostname", "s", "", {title: "If not empty, DNS server will resolve given host name to the IP address of AP"}]  
 
   - ["wifi.sta", "o", {title: "WiFi Station Config"}]
   - ["wifi.sta.enable", "b", {title: "Connect to existing WiFi"}]
@@ -85,8 +85,10 @@ conds:
       config_schema:
         - ["wifi.ap.keep_enabled", "b", true, {title: "Keep AP enabled when station is on"}]
         - ["wifi.ap.bandwidth_20mhz", "b", false, {title: "enable 20MHz bandwidth AP operation"}]
+        - ["wifi.ap.protocol", "s", "BGN", {title: "Wi-Fi Protocol for AP Mode, defaults to B, G, N"}]
         - ["wifi.sta_ps_mode", "i", 0, {title: "Power save mode for station: 0 - none, 1 - min, 2 - max."}]
         - ["wifi.sta_all_chan_scan", "b", false, {title: "true to scan all channels or false to perform fast scan"}]
+        - ["wifi.sta.protocol", "s", "BGN", {title: "Wi-Fi Protocol for STA Mode, defaults to B, G, N"}]
       cdefs:
         MGOS_WIFI_ENABLE_AP_STA: 1
 

--- a/src/esp32/esp32_wifi.c
+++ b/src/esp32/esp32_wifi.c
@@ -327,6 +327,12 @@ bool mgos_wifi_dev_sta_setup(const struct mgos_config_wifi_sta *cfg) {
     tcpip_adapter_dhcpc_start(TCPIP_ADAPTER_IF_STA);
   }
 
+  r = esp_wifi_set_protocol(WIFI_IF_STA, protocol);
+  if (r != ESP_OK) {
+    LOG(LL_ERROR, ("Failed to set STA protocol: %d", r));
+    goto out;
+  }
+
   r = esp_wifi_set_config(WIFI_IF_STA, &wcfg);
   if (r != ESP_OK) {
     LOG(LL_ERROR, ("Failed to set STA config: %d", r));
@@ -480,6 +486,11 @@ bool mgos_wifi_dev_ap_setup(const struct mgos_config_wifi_ap *cfg) {
   r = esp_wifi_set_bandwidth(WIFI_IF_AP, bw);
   if (r != ESP_OK) {
     LOG(LL_ERROR, ("WiFi AP: Failed to set the bandwidth: %d", r));
+    goto out;
+  }
+  r = esp_wifi_set_protocol(WIFI_IF_AP, protocol);
+  if (r != ESP_OK) {
+    LOG(LL_ERROR, ("WiFi AP: Failed to set the protocol: %d", r));
     goto out;
   }
   r = tcpip_adapter_dhcps_start(TCPIP_ADAPTER_IF_AP);


### PR DESCRIPTION
Allows user to set wifi protocol in ESP32, enabling 802.11 LR mode

By default, protocol is set to BGN, but other modes can be set according to ESP32 wi-fi-protocol-mode.
https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/wifi.html#wi-fi-protocol-mode